### PR TITLE
Fix qwen3 prompt selection in reset

### DIFF
--- a/secgym/agents/baseline_agent.py
+++ b/secgym/agents/baseline_agent.py
@@ -274,7 +274,7 @@ class BaselineAgent:
 
         self.step_count = 0
         sys_prompt = BASE_PROMPT
-        if "o1" in self.config_list[0]['model'] or "o3" in self.config_list[0]['model'] or "o4" in self.config_list[0]['model'] or "meta-llama" in self.config_list[0]['model'] or "qwen3" in self.config_list[0]['model']:
+        if "o1" in self.config_list[0]['model'] or "o3" in self.config_list[0]['model'] or "o4" in self.config_list[0]['model'] or "meta-llama" in self.config_list[0]['model']:
             sys_prompt = O1_PROMPT
         elif "r1" in self.config_list[0]['model'] or "R1" in self.config_list[0]['model'] or "qwen3" in self.config_list[0]['model']:
             sys_prompt = R1_PROMPT


### PR DESCRIPTION
Remove 'qwen3' from the O1 prompt branch in `reset()` so that it reaches the R1 prompt branch, keeping prompt selection consistent with `__init__()` and the `<answer>` parser in `act()`.

Related observations not addressed by this commit:
- 'qwen3' model-name detection is case-sensitive.
- act() contains an if/else with same branches that execute the same statement.